### PR TITLE
Remove lodash dependency in favor of Object.assign.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "form-urlencoded": "^3.0.1",
     "invariant": "^2.2.4",
     "is-stream": "^1.1.0",
-    "lodash": "^4.17.14",
     "lodash.snakecase": "^4.1.1",
     "node-fetch": "^2.2.0"
   }

--- a/src/dwolla/Auth.js
+++ b/src/dwolla/Auth.js
@@ -1,6 +1,6 @@
 var fetch = require("node-fetch").default;
 var formurlencoded = require("form-urlencoded").default;
-var assign = require("lodash/assign");
+var assign = Object.assign;
 var invariant = require("invariant");
 var rejectEmptyKeys = require("../util/rejectEmptyKeys");
 var toJson = require("../util/toJson");

--- a/src/dwolla/Token.js
+++ b/src/dwolla/Token.js
@@ -2,7 +2,7 @@ var fetch = require("node-fetch").default;
 var formurlencoded = require("form-urlencoded").default;
 var rejectEmptyKeys = require("../util/rejectEmptyKeys");
 var isFormData = require("../util/isFormData");
-var assign = require("lodash/assign");
+var assign = Object.assign;
 var Promise = require("bluebird");
 
 fetch.Promise = Promise;

--- a/test/dwolla/Client.test.js
+++ b/test/dwolla/Client.test.js
@@ -1,4 +1,4 @@
-var assign = require("lodash/assign");
+var assign = Object.assign;
 var chai = require("chai");
 var assert = chai.assert;
 var expect = chai.expect;

--- a/test/dwolla/Token.test.js
+++ b/test/dwolla/Token.test.js
@@ -2,7 +2,7 @@ var chai = require("chai");
 var expect = chai.expect;
 var nock = require("nock");
 var toFormData = require("../../src/util/toFormData");
-var assign = require("lodash/assign");
+var assign = Object.assign;
 
 var chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);


### PR DESCRIPTION
Remove dependency on `lodash` in favor of ES6 `Object.assign`, supported since Node v4.