### PR TITLE
Fixed unit test for token manager

### DIFF
--- a/test/dwolla/TokenManager.test.js
+++ b/test/dwolla/TokenManager.test.js
@@ -12,7 +12,7 @@ describe("TokenManager", function() {
     "content-type": "application/x-www-form-urlencoded",
     "user-agent": require("../../src/dwolla/userAgent")
   };
-  var existingToken = Promise.resolve("existing-token");
+  var existingToken = "existing-token";
   var accessToken = "access-token";
 
   this.beforeEach(function() {
@@ -30,7 +30,7 @@ describe("TokenManager", function() {
 
   it("returns existing token if fresh", function(done) {
     var tokenManager = require("../../src/dwolla/TokenManager")(client, {
-      instance: existingToken,
+      instance: Promise.resolve(existingToken),
       expiresIn: 3600,
       updatedAt: now()
     });
@@ -43,7 +43,7 @@ describe("TokenManager", function() {
 
   it("gets new token when existing token stale", function(done) {
     var tokenManager = require("../../src/dwolla/TokenManager")(client, {
-      instance: existingToken,
+      instance: Promise.resolve(existingToken),
       expiresIn: 30,
       updatedAt: now()
     });


### PR DESCRIPTION
There is an error in one of the tests for Token Manager.

Would also like to note that this has been passing CI because in Node 10/12/14 the error will be printed out, but won't actually cause the build to fail. For Node 16 that has been fixed.

# Reproduction steps

Using node `16.3.2`

`npm i`
`npm run test`

```
  1) TokenManager
       returns existing token if fresh:
     Uncaught AssertionError: expected 'existing-token' to equal {}
      at /Users/pting/dev/dwolla-v2-node/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
```

Using node `14.9.0`

`npm i`
`npm run test`

```
  TokenManager
    ✓ gets new token when no existing token
    ✓ returns existing token if fresh
(node:94590) UnhandledPromiseRejectionWarning: AssertionError: expected 'existing-token' to equal {}
    at /Users/pting/dev/dwolla-v2-node/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
(node:94590) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:94590) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
    ✓ gets new token when existing token stale
```