### PR TITLE
Don't directly import FormData (when performing checks) since it should be an optional dependency

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -1,10 +1,10 @@
-import FormData from "form-data";
 import formUrlEncoded from "form-urlencoded";
 import fetch, { Headers, Response as FetchResponse } from "node-fetch";
 import { Client } from "./client";
 import { rejectEmptyKeys, userAgent } from "./utils";
 import { AuthResponse } from "./auth";
 import { TokenState } from "./token-manager";
+import isFormData from "./utils/isFormData";
 
 export interface Response {
     body: any;
@@ -140,9 +140,9 @@ export class Token {
             method: "POST",
             headers: Object.assign(
                 this.#getHeaders(headers),
-                body instanceof FormData ? body.getHeaders() : { "Content-Type": "application/json" }
+                isFormData(body) ? body.getHeaders() : { "Content-Type": "application/json" }
             ),
-            body: body instanceof FormData ? body : JSON.stringify(body)
+            body: isFormData(body) ? body : JSON.stringify(body)
         });
 
         const parsedResponse: Response = await this.#parseResponse(rawResponse);

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,10 +1,9 @@
 import formUrlEncoded from "form-urlencoded";
 import fetch, { Headers, Response as FetchResponse } from "node-fetch";
 import { Client } from "./client";
-import { rejectEmptyKeys, userAgent } from "./utils";
+import { isFormData, rejectEmptyKeys, userAgent } from "./utils";
 import { AuthResponse } from "./auth";
 import { TokenState } from "./token-manager";
-import isFormData from "./utils/isFormData";
 
 export interface Response {
     body: any;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
+import isFormData from "./isFormData";
 import rejectEmptyKeys from "./rejectEmptyKeys";
 import toFormData from "./toFormData";
 import unixSeconds from "./unixSeconds";
 import userAgent from "./userAgent";
 
-export { rejectEmptyKeys, toFormData, unixSeconds, userAgent };
+export { isFormData, rejectEmptyKeys, toFormData, unixSeconds, userAgent };

--- a/src/utils/isFormData.ts
+++ b/src/utils/isFormData.ts
@@ -1,0 +1,10 @@
+import { Stream } from "node:stream";
+import FormData from "form-data";
+
+function isStream(stream: unknown): stream is Stream {
+    return stream !== null && typeof stream === "object" && typeof (stream as Stream).pipe === "function";
+}
+
+export default function isFormData(obj: unknown): obj is FormData {
+    return isStream(obj) && typeof (obj as FormData).getBoundary === "function";
+}


### PR DESCRIPTION
When using `instanceof`, the output will directly import the dependency. Since FormData is meant to be an optional dependency, instead of directly importing it, this PR will check if an object is equal to FormData by checking its a Stream instance and its properties.