### PR TITLE
Fix document upload example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ console.log("Created Resource: ", response.headers.get("Location"));
 // Note: Requires form-data peer dependency to be downloaded and installed
 const formData = new FormData();
 formData.append("documentType", "license");
-formData.append("file", ffs.createReadStream("mclovin.jpg", {
+formData.append("file", ffs.createReadStream("mclovin.jpg"), {
     contentType: "image/jpeg",
     filename: "mclovin.jpg",
     knownLength: fs.statSync("mclovin.jpg").size
-}));
+});
 
 const response = await dwolla.post(`${customerUrl}/documents`, formData);
 console.log("Created Resource: ", response.headers.get("Location"));


### PR DESCRIPTION
The example provided in the README for Document Upload is incorrect. The `contentType`, `filename` and `knownLength` options should be provided as a third argument to the `append` function, not as a second argument to the `createReadStream` function.

An example can be found in the readme for form-data: https://github.com/form-data/form-data#void-append-string-field-mixed-value--mixed-options-