### PR TITLE
DEV-1816: ci: switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: npm ci
@@ -21,13 +21,14 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# JetBrains IDE
+.idea


### PR DESCRIPTION
## Summary

Switches npm publishing from a long-lived `NPM_TOKEN` to OIDC trusted
publishing. Each release authenticates with a short-lived credential
issued at runtime, and packages get provenance attestations automatically.

## Changes

- Added `id-token: write` permission to the publish job
- Bumped publish-job Node 16 → 24 (trusted publishing needs npm 11.5+)
- Removed `NODE_AUTH_TOKEN` and the `npm_token` secret reference
- Bumped `actions/checkout` and `actions/setup-node` to v4

## Test plan

- [x] Trusted publisher configured on npmjs.com

Test the following after merging:
- [ ] Cut a patch release and confirm publish succeeds without a token
- [ ] Verify "Provenance" badge appears on the new
- [ ] Delete `NPM_TOKEN` secret and revoke the npm token