### PR TITLE
Disable node-fetch gzip on token request to fix ERR_STREAM_PREMATURE_CLOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ const response = await dwolla.post("customers", {
 
 ## Changelog
 
+- **3.4.2** Disable automatic gzip handling on all `node-fetch` requests (pass `compress: false`) to avoid false-positive `ERR_STREAM_PREMATURE_CLOSE` errors on keep-alive sockets under Node.js v24.17.0+. See [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).
+- **3.4.1** Switch npm publishing to OIDC trusted publishing.
 - **[3.4.0](https://github.com/Dwolla/dwolla-v2-node/releases/tag/v3.4.0)** Update `form-urlencoded` version to allow `{ skipIndex: true, skipBracket: true }` options to be passed in. Thanks, [@MarcMouallem](https://github.com/MarcMouallem)!
 - **3.3.0** Remove `lodash` as a dependency in favor of `Object.assign`
 - **3.2.3** Update version and changelog

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const response = await dwolla.post("customers", {
 
 ## Changelog
 
-- **3.4.2** Disable automatic gzip handling on all `node-fetch` requests (pass `compress: false`) to avoid false-positive `ERR_STREAM_PREMATURE_CLOSE` errors on keep-alive sockets under Node.js v24.17.0+. See [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).
+- **3.4.2** Disable automatic gzip handling on the OAuth token request (pass `compress: false`) to avoid false-positive `ERR_STREAM_PREMATURE_CLOSE` errors on keep-alive sockets under Node.js v24.17.0+. See [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).
 - **3.4.1** Switch npm publishing to OIDC trusted publishing.
 - **[3.4.0](https://github.com/Dwolla/dwolla-v2-node/releases/tag/v3.4.0)** Update `form-urlencoded` version to allow `{ skipIndex: true, skipBracket: true }` options to be passed in. Thanks, [@MarcMouallem](https://github.com/MarcMouallem)!
 - **3.3.0** Remove `lodash` as a dependency in favor of `Object.assign`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dwolla-v2",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dwolla-v2",
-      "version": "3.4.0",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dwolla-v2",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Dwolla V2 API client",
   "main": "src/index.js",
   "files": [

--- a/src/dwolla/Auth.js
+++ b/src/dwolla/Auth.js
@@ -36,6 +36,7 @@ function performOnGrantCallback(client, token) {
 function requestToken(client, params) {
   return fetch(client.tokenUrl, {
     method: "POST",
+    compress: false,
     headers: {
       "content-type": "application/x-www-form-urlencoded",
       "user-agent": require("../../src/dwolla/userAgent")

--- a/src/dwolla/Token.js
+++ b/src/dwolla/Token.js
@@ -78,7 +78,6 @@ function handleResponse(res) {
 
 Token.prototype.get = function(path, query, headers) {
   return fetch(getUrl(this, path, query), {
-    compress: false,
     headers: getHeaders(this, headers)
   }).then(handleResponse);
 };
@@ -86,7 +85,6 @@ Token.prototype.get = function(path, query, headers) {
 Token.prototype.post = function(path, body, headers) {
   return fetch(getUrl(this, path), {
     method: "POST",
-    compress: false,
     headers: assign(
       getHeaders(this, headers),
       isFormData(body)
@@ -100,7 +98,6 @@ Token.prototype.post = function(path, body, headers) {
 Token.prototype.delete = function(path, query, headers) {
   return fetch(getUrl(this, path, query), {
     method: "DELETE",
-    compress: false,
     headers: getHeaders(this, headers)
   }).then(handleResponse);
 };

--- a/src/dwolla/Token.js
+++ b/src/dwolla/Token.js
@@ -78,6 +78,7 @@ function handleResponse(res) {
 
 Token.prototype.get = function(path, query, headers) {
   return fetch(getUrl(this, path, query), {
+    compress: false,
     headers: getHeaders(this, headers)
   }).then(handleResponse);
 };
@@ -85,6 +86,7 @@ Token.prototype.get = function(path, query, headers) {
 Token.prototype.post = function(path, body, headers) {
   return fetch(getUrl(this, path), {
     method: "POST",
+    compress: false,
     headers: assign(
       getHeaders(this, headers),
       isFormData(body)
@@ -98,6 +100,7 @@ Token.prototype.post = function(path, body, headers) {
 Token.prototype.delete = function(path, query, headers) {
   return fetch(getUrl(this, path, query), {
     method: "DELETE",
+    compress: false,
     headers: getHeaders(this, headers)
   }).then(handleResponse);
 };


### PR DESCRIPTION
## Summary

Passes `compress: false` on the OAuth token request in `src/dwolla/Auth.js` so node-fetch skips the gunzip pipeline that surfaces false-positive `ERR_STREAM_PREMATURE_CLOSE` errors.

Node.js v24.17.0+ changed `http.Agent` keep-alive socket teardown timing (response queue poisoning fix), which exposes a latent `node-fetch@2` bug: gzip + chunked responses read over a reused keep-alive socket raise a premature-close error from the Gunzip stream even though the full payload arrived. See [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).

Verified against node-fetch 2.7.0 source — `compress: false` both omits the `Accept-Encoding` request header (`lib/index.js:1359`, so the upstream returns an uncompressed `Content-Length` body) and skips the `zlib.createGunzip()` decode path (`lib/index.js:1664`).

## Scope: token endpoint only

Two customer reports (production `api.dwolla.com` and sandbox `api-sandbox.dwolla.com`) show every failure occurs **at the `/token` fetch, before any downstream API call runs** — e.g. a `getOrCreateDwollaCustomer` call errors out during token retrieval. "Multiple API calls affected" means many features broke because each needs a token first; the `Token.js` data-call fetches (`get`/`post`/`delete`) were never reached and show no evidence of being affected.

The fix is therefore scoped to the token request only:
- The token payload is ~109 bytes, so disabling gzip there has no cost.
- Leaving compression enabled on the data calls preserves gzip on potentially large list responses (customers, transfers). If those are ever confirmed affected, the upstream Node fix ([PR #64004](https://github.com/nodejs/node/pull/64004)) or a keep-alive adjustment would be preferable to permanently disabling compression.

## Changes

- Add `compress: false` to the token request in `Auth.js`
- Bump version 3.4.1 → 3.4.2; sync `package-lock.json` (was stale at 3.4.0)
- Add 3.4.2 changelog entry referencing nodejs/node#63989

## Testing

- eslint and prettier pass
- Test suite: 14 passing / 5 failing — the 5 failures are pre-existing on clean `main` (a Node v22/nock stream incompatibility in the test harness), not introduced by this change